### PR TITLE
Fix NullPointerException in settings sliders

### DIFF
--- a/app/src/main/java/com/best/deskclock/settings/custompreference/AlarmVolumePreference.java
+++ b/app/src/main/java/com/best/deskclock/settings/custompreference/AlarmVolumePreference.java
@@ -53,8 +53,20 @@ public class AlarmVolumePreference extends Preference {
     private Runnable mRingtoneStopRunnable;
     private boolean mIsPreviewPlaying = false;
 
+    public AlarmVolumePreference(Context context) {
+        this(context, null);
+    }
+
     public AlarmVolumePreference(Context context, AttributeSet attrs) {
-        super(context, attrs);
+        this(context, attrs, androidx.preference.R.attr.preferenceStyle);
+    }
+
+    public AlarmVolumePreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, 0);
+    }
+
+    public AlarmVolumePreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
         setLayoutResource(R.layout.settings_preference_slider_layout);
     }
 
@@ -79,6 +91,9 @@ public class AlarmVolumePreference extends Preference {
         mMinVolume = RingtoneUtils.getAlarmMinVolume(mAudioManager);
         int maxVolume = mAudioManager.getStreamMaxVolume(STREAM_ALARM) - mMinVolume;
         mSlider = (Slider) holder.findViewById(R.id.slider);
+        if (mSlider == null) {
+            return;
+        }
         mSlider.setValueTo(maxVolume);
         mSlider.setValueFrom(0f);
         mSlider.setStepSize(1f);

--- a/app/src/main/java/com/best/deskclock/settings/custompreference/CustomSliderPreference.java
+++ b/app/src/main/java/com/best/deskclock/settings/custompreference/CustomSliderPreference.java
@@ -102,8 +102,20 @@ public class CustomSliderPreference extends Preference {
     private Runnable mRingtoneStopRunnable;
     private boolean mIsPreviewPlaying = false;
 
-    public CustomSliderPreference(@NonNull Context context, @Nullable AttributeSet attrs) {
-        super(context, attrs);
+    public CustomSliderPreference(Context context) {
+        this(context, null);
+    }
+
+    public CustomSliderPreference(Context context, AttributeSet attrs) {
+        this(context, attrs, androidx.preference.R.attr.preferenceStyle);
+    }
+
+    public CustomSliderPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, 0);
+    }
+
+    public CustomSliderPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
         setLayoutResource(R.layout.settings_preference_slider_layout);
     }
 
@@ -127,6 +139,9 @@ public class CustomSliderPreference extends Preference {
         holder.itemView.setClickable(false);
 
         mSlider = (Slider) holder.findViewById(R.id.slider);
+        if (mSlider == null) {
+            return;
+        }
         configureSliderBounds();
         mSlider.setStepSize(1f);
 


### PR DESCRIPTION
This PR fixes a NullPointerException occurring in the Alarm Settings.

The crash happened because `AlarmVolumePreference` and `CustomSliderPreference` were missing standard Preference constructors. When the `PreferenceInflater` used one of the missing constructors, `setLayoutResource()` was never called, leading to a default layout being used which did not contain the `@id/slider` view.

Changes:
- Implemented all standard Preference constructors in `AlarmVolumePreference` and `CustomSliderPreference`.
- Ensured `setLayoutResource(R.layout.settings_preference_slider_layout)` is called in the base constructor.
- Added defensive null checks for `mSlider` in `onBindViewHolder`.
- Verified the fix by checking compilation and reviewing the logic.

---
*PR created automatically by Jules for task [14012196085075903270](https://jules.google.com/task/14012196085075903270) started by @gx-bangsong*